### PR TITLE
cleanup the client and server interaction

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,16 @@
+use std::{error::Error, process::exit};
+
 use clap::{Parser, Subcommand};
+
+use crate::{
+    errors::CommunicationError, message::Message, output::Output, schema::Schema, store::Store,
+    vault::interface::VaultInterface, Password,
+};
 
 #[derive(Parser)]
 pub struct CliArgs {
     #[command(subcommand)]
-    pub command: Option<CLICommands>,
+    pub command: CLICommands,
 }
 
 #[derive(Subcommand)]
@@ -54,4 +61,136 @@ pub enum BackupCommand {
     List,
     /// restore from existing backups
     Restore,
+}
+
+impl CliArgs {
+    pub fn run() {
+        let args = CliArgs::parse();
+        args.execute()
+    }
+
+    pub fn execute(self) {
+        match self.command {
+            CLICommands::Gen(args) => {
+                if let Some(p) = args.execute() {
+                    println!("{p}");
+                } else {
+                    println!("Could not satisfy password spec constraints");
+                }
+            }
+
+            command => match Self::construct_message(command) {
+                Ok(message) => match VaultInterface::receive(message) {
+                    Ok(output) => {
+                        if let Err(e) = output.finish() {
+                            println!("Encountered error: {}", e);
+                        }
+                    }
+                    Err(e) => {
+                        println!("Encountered error: {}", e);
+                    }
+                },
+                Err(e) => {
+                    println!("Encountered error: {}", e);
+                    exit(1)
+                }
+            },
+        }
+    }
+
+    fn construct_message(command: CLICommands) -> Result<Message, Box<dyn Error>> {
+        match command {
+            CLICommands::Get { key } => {
+                let password = Self::get_password("Vault password:")?;
+                Ok(Message::Get(password, key))
+            }
+            CLICommands::Update { key } => {
+                let schema = Self::get_schema()?;
+                match schema.get(&key) {
+                    None => Err(Box::new(CommunicationError::NoEntry)),
+                    Some(style) => {
+                        let value = Store::prompt(style)?;
+                        let password = Self::get_password("Vault password:")?;
+                        Ok(Message::Update(password, key, value))
+                    }
+                }
+            }
+            CLICommands::Delete { key } => {
+                let password = Self::get_password("Vault password:")?;
+                Ok(Message::Delete(password, key))
+            }
+            CLICommands::New { style } => {
+                let schema = Self::get_schema()?;
+                match style {
+                    EntryStyle::Password { name } => Self::handle_new(schema, name, "password"),
+                    EntryStyle::UsernamePassword { name } => {
+                        Self::handle_new(schema, name, "username-password")
+                    }
+                }
+            }
+            CLICommands::Rotate => {
+                let password = Self::get_password("Vault password:")?;
+                let new_password = Self::get_password_confirm("New vault password:")?;
+                Ok(Message::Rotate(password, new_password))
+            }
+            CLICommands::Backup { option } => match option {
+                None => {
+                    let password = Self::get_password("Vault password:")?;
+                    Ok(Message::Backup(password))
+                }
+                Some(BackupCommand::List) => Ok(Message::BackupList),
+                Some(BackupCommand::Restore) => {
+                    match VaultInterface::receive(Message::BackupList)? {
+                        Output::BackupFiles(files) => {
+                            let backup_file = inquire::Select::new("Restore from:", files)
+                                .with_help_message("Choose the backup file to restore from")
+                                .prompt()?;
+                            let password = Self::get_password("Current password")?;
+                            let backup_password = Self::get_password("Backup's password:")?;
+                            Ok(Message::Restore(password, backup_password, backup_file))
+                        }
+                        _ => Err(Box::new(CommunicationError::UnexpectedOutput)),
+                    }
+                }
+            },
+            CLICommands::List => Ok(Message::Schema),
+
+            _ => todo!(),
+        }
+    }
+
+    fn handle_new(schema: Schema, key: String, style: &str) -> Result<Message, Box<dyn Error>> {
+        match schema.get(&key) {
+            None => {
+                let value = Store::prompt(style)?;
+                let password = Self::get_password("Vault password:")?;
+                Ok(Message::Update(password, key, value))
+            }
+            Some(_) => Err(Box::new(CommunicationError::ExistingEntry)),
+        }
+    }
+
+    fn get_schema() -> Result<Schema, Box<dyn Error>> {
+        match VaultInterface::receive(Message::Schema)? {
+            Output::Schema(schema) => Ok(schema),
+            _ => Err(Box::new(CommunicationError::UnexpectedOutput)),
+        }
+    }
+
+    fn get_password(prompt: &str) -> Result<Password, Box<dyn Error>> {
+        let password = inquire::Password::new(prompt)
+            .without_confirmation()
+            .with_display_toggle_enabled()
+            .with_display_mode(inquire::PasswordDisplayMode::Masked)
+            .prompt()?;
+        Ok(password)
+    }
+
+    fn get_password_confirm(prompt: &str) -> Result<Password, Box<dyn Error>> {
+        let password = inquire::Password::new(prompt)
+            .with_display_toggle_enabled()
+            .with_display_mode(inquire::PasswordDisplayMode::Masked)
+            .prompt()?;
+        Ok(password)
+    }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -117,6 +117,14 @@ impl From<Vec<Command>> for Commands {
     }
 }
 
+impl From<Command> for Commands {
+    fn from(value: Command) -> Self {
+        Self {
+            commands: vec![value],
+        }
+    }
+}
+
 impl From<Commands> for Instructions {
     fn from(value: Commands) -> Self {
         Instructions::Commands(value)

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,32 +1,10 @@
-use std::error::Error;
-
-use crate::{
-    cli::{CLICommands, EntryStyle},
-    errors::ConversionError,
-    schema::Schema,
-    store::Store,
-};
-
-#[derive(Debug, Clone)]
-pub enum Instructions {
-    Interaction(Interaction),
-    Commands(Commands),
-}
+use crate::store::Store;
 
 #[derive(Debug, Clone)]
 pub enum Command {
     Read { key: String },
     Update { key: String, value: Store },
     Delete { key: String },
-}
-
-#[derive(Debug, Clone)]
-pub enum Interaction {
-    List,
-    Backup,
-    BackupList,
-    BackupRestore,
-    Rotate,
 }
 
 #[derive(Debug, Clone)]
@@ -64,53 +42,6 @@ impl Commands {
     // }
 }
 
-impl Instructions {
-    fn handle_new(name: String, schema: Schema, style: &str) -> Result<Self, Box<dyn Error>> {
-        match schema.get(&name) {
-            Some(_) => Err(Box::new(ConversionError::Exists)),
-            None => {
-                let value = Store::prompt(style)?;
-                let commands: Commands = vec![Command::Update { key: name, value }].into();
-                Ok(commands.into())
-            }
-        }
-    }
-    pub fn from_commands(commands: CLICommands, schema: Schema) -> Result<Self, Box<dyn Error>> {
-        match commands {
-            CLICommands::New { style } => match style {
-                EntryStyle::Password { name } => Self::handle_new(name, schema, "password"),
-                EntryStyle::UsernamePassword { name } => {
-                    Self::handle_new(name, schema, "username-password")
-                }
-            },
-            CLICommands::Get { key } => {
-                let commands: Commands = vec![Command::Read { key }].into();
-                Ok(commands.into())
-            }
-            CLICommands::Update { key } => match schema.get(&key) {
-                None => Err(Box::new(ConversionError::NoEntry)),
-                Some(value) => {
-                    let value = Store::prompt(value)?;
-                    let commands: Commands = vec![Command::Update { key, value }].into();
-                    Ok(commands.into())
-                }
-            },
-            CLICommands::Delete { key } => {
-                let commands: Commands = vec![Command::Delete { key }].into();
-                Ok(commands.into())
-            }
-            CLICommands::List => Ok(Interaction::List.into()),
-            CLICommands::Backup { option } => match option {
-                None => Ok(Interaction::Backup.into()),
-                Some(crate::cli::BackupCommand::List) => Ok(Interaction::BackupList.into()),
-                Some(crate::cli::BackupCommand::Restore) => Ok(Interaction::BackupRestore.into()),
-            },
-            CLICommands::Rotate => Ok(Interaction::Rotate.into()),
-            _ => todo!(),
-        }
-    }
-}
-
 impl From<Vec<Command>> for Commands {
     fn from(value: Vec<Command>) -> Self {
         Self { commands: value }
@@ -122,17 +53,5 @@ impl From<Command> for Commands {
         Self {
             commands: vec![value],
         }
-    }
-}
-
-impl From<Commands> for Instructions {
-    fn from(value: Commands) -> Self {
-        Instructions::Commands(value)
-    }
-}
-
-impl From<Interaction> for Instructions {
-    fn from(value: Interaction) -> Self {
-        Instructions::Interaction(value)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -106,3 +106,22 @@ impl Display for SchemaError {
         }
     }
 }
+
+#[derive(Debug)]
+pub enum CommunicationError {
+    UnexpectedOutput,
+    NoEntry,
+    ExistingEntry,
+}
+
+impl Error for CommunicationError {}
+
+impl Display for CommunicationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnexpectedOutput => write!(f, "Received unexpected output from vault"),
+            Self::NoEntry => write!(f, "Expected existing entry, but no entry exists"),
+            Self::ExistingEntry => write!(f, "Expected no existing entry, but entry exists"),
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,29 +20,6 @@ impl Display for SaveError {
 }
 
 #[derive(Debug)]
-pub enum ConversionError {
-    PasswordGeneration,
-    NoEntry,
-    Exists,
-    PromptError,
-}
-
-impl Error for ConversionError {}
-
-impl Display for ConversionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::PasswordGeneration => {
-                write!(f, "Constraints for password generation could not be met")
-            }
-            Self::NoEntry => write!(f, "No relevant entry found in schema"),
-            Self::Exists => write!(f, "Entry already exists"),
-            Self::PromptError => write!(f, "Error during prompting"),
-        }
-    }
-}
-
-#[derive(Debug)]
 pub enum EncryptionError {
     Encryption,
 }
@@ -68,21 +45,6 @@ impl Display for DecryptionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             DecryptionError::Decryption => write!(f, "Failed to decrypt data"),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum InteractionError {
-    DifferentPasswords,
-}
-
-impl Error for InteractionError {}
-
-impl Display for InteractionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::DifferentPasswords => write!(f, "Given passwords don't match"),
         }
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -15,7 +15,7 @@ use crate::{
     errors::SaveError,
     schema::Schema,
     utils::{format_date, now, read_date},
-    vault_encrypted::{RecordEncrypted, VaultEncrypted},
+    vault::encrypted::{RecordEncrypted, VaultEncrypted},
 };
 
 // TODO: create encrypted files that need to be given a password/key to open

--- a/src/file.rs
+++ b/src/file.rs
@@ -223,7 +223,7 @@ where
         }
     }
 
-    pub fn check(&self) -> bool {
+    pub fn exists(&self) -> bool {
         self.path().exists()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ pub mod cli;
 pub mod command;
 pub mod errors;
 pub mod file;
+pub mod message;
 pub mod operation;
 pub mod output;
 pub mod reads;
@@ -127,4 +128,5 @@ pub mod secure;
 pub mod store;
 pub mod utils;
 pub mod vault;
-pub mod vault_encrypted;
+
+pub type Password = String;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,34 @@
-use clap::Parser;
-use pants_store::{cli::CliArgs, vault::interface::VaultInterface};
+use pants_store::cli::CliArgs;
 
 fn main() {
-    let args = CliArgs::parse();
-    if let Some(command) = args.command {
-        match command {
-            pants_store::cli::CLICommands::Gen(args) => {
-                if let Some(p) = args.execute() {
-                    println!("{p}");
-                } else {
-                    println!("Could not satisfy password spec constraints");
-                }
-            }
-            _ => match VaultInterface::interaction(command) {
-                Ok(output) => {
-                    let res = output.finish();
-                    if let Err(e) = res {
-                        println!("Encountered error: {}", e);
-                    }
-                }
-                Err(e) => {
-                    println!("Encountered error: {}", e);
-                }
-            },
-        }
-    }
+    CliArgs::run()
 }
+
+// fn main() {
+//     let args = CliArgs::parse();
+//     if let Some(command) = args.command {
+//         match command {
+//             pants_store::cli::CLICommands::Gen(args) => {
+//                 if let Some(p) = args.execute() {
+//                     println!("{p}");
+//                 } else {
+//                     println!("Could not satisfy password spec constraints");
+//                 }
+//             }
+//             _ => match VaultInterface::interaction(command) {
+//                 Ok(output) => {
+//                     let res = output.finish();
+//                     if let Err(e) = res {
+//                         println!("Encountered error: {}", e);
+//                     }
+//                 }
+//                 Err(e) => {
+//                     println!("Encountered error: {}", e);
+//                 }
+//             },
+//         }
+//     }
+// }
 // fn main() {
 //     let validator = |input: &str| {
 //         if input.chars().count() == 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use pants_store::{cli::CliArgs, vault_encrypted::VaultInterface};
+use pants_store::{cli::CliArgs, vault::interface::VaultInterface};
 
 fn main() {
     let args = CliArgs::parse();

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,4 @@
-use std::path::PathBuf;
-
-use crate::{store::Store, Password};
+use crate::{file::BackupFile, store::Store, Password};
 
 // messages that are used to send to the server
 pub enum Message {
@@ -9,7 +7,7 @@ pub enum Message {
     Delete(Password, String),
     Backup(Password),
     Rotate(Password, Password),
-    Restore(Password, Password, PathBuf),
+    Restore(Password, Password, BackupFile),
     Schema,
     BackupList,
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,0 +1,15 @@
+use std::path::PathBuf;
+
+use crate::{store::Store, Password};
+
+// messages that are used to send to the server
+pub enum Message {
+    Get(Password, String),
+    Update(Password, String, Store),
+    Delete(Password, String),
+    Backup(Password),
+    Rotate(Password, Password),
+    Restore(Password, Password, PathBuf),
+    Schema,
+    BackupList,
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,18 +1,10 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Schema {
-    data: HashMap<String, String>,
-}
-
-impl Default for Schema {
-    fn default() -> Self {
-        Schema {
-            data: HashMap::new(),
-        }
-    }
+    pub data: HashMap<String, String>,
 }
 
 impl Schema {
@@ -39,5 +31,23 @@ impl Schema {
 impl From<HashMap<String, String>> for Schema {
     fn from(value: HashMap<String, String>) -> Self {
         Self { data: value }
+    }
+}
+
+impl IntoIterator for Schema {
+    type Item = (String, String);
+    type IntoIter = std::collections::hash_map::IntoIter<String, String>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
+    }
+}
+
+impl Display for Schema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (key, value) in self.data.iter() {
+            writeln!(f, "{}: {}", key, value)?;
+        }
+        Ok(())
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -7,6 +7,14 @@ pub struct Schema {
     data: HashMap<String, String>,
 }
 
+impl Default for Schema {
+    fn default() -> Self {
+        Schema {
+            data: HashMap::new(),
+        }
+    }
+}
+
 impl Schema {
     pub fn new(data: HashMap<String, String>) -> Self {
         Self { data }

--- a/src/vault/encrypted.rs
+++ b/src/vault/encrypted.rs
@@ -1,0 +1,285 @@
+use std::error::Error;
+
+use aes_gcm::{aead::OsRng, Aes256Gcm, Key};
+use argon2::password_hash::SaltString;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    action::Record,
+    secure::{Encrypted, SecureData},
+    vault::Vault,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PasswordEncrypted<Data> {
+    pub data: Encrypted<Data>,
+    pub salt: String,
+}
+
+impl<Data> SecureData for PasswordEncrypted<Data> {
+    type Item = Data;
+    fn salt(&self) -> &str {
+        &self.salt
+    }
+    fn data(&self) -> &Encrypted<Self::Item> {
+        &self.data
+    }
+}
+
+pub type VaultEncrypted = PasswordEncrypted<Vault>;
+
+impl VaultEncrypted {
+    pub fn new(password: String) -> Result<Self, Box<dyn Error>> {
+        let salt = SaltString::generate(&mut OsRng).to_string();
+        let key = Self::get_key(&salt, password);
+        Encrypted::encrypt(&Vault::new(), key).map(|vault| Self { data: vault, salt })
+    }
+
+    pub fn update(&mut self, data: &Vault, key: Key<Aes256Gcm>) -> Result<(), Box<dyn Error>> {
+        let updated = Encrypted::encrypt(data, key)?;
+        self.data = updated;
+        Ok(())
+    }
+}
+
+pub type RecordEncrypted = PasswordEncrypted<Record>;
+
+impl RecordEncrypted {
+    pub fn new(password: String) -> Result<Self, Box<dyn Error>> {
+        let salt = SaltString::generate(&mut OsRng).to_string();
+        let key = Self::get_key(&salt, password);
+        Encrypted::encrypt(&Record::new(), key).map(|vault| Self { data: vault, salt })
+    }
+
+    pub fn update(&mut self, data: &Record, key: Key<Aes256Gcm>) -> Result<(), Box<dyn Error>> {
+        let updated = Encrypted::encrypt(data, key)?;
+        self.data = updated;
+        Ok(())
+    }
+}
+
+// pub struct VaultInterface {
+//     vault_file: VaultFile,
+//     schema_file: Rc<RefCell<SchemaFile>>,
+//     vault: VaultEncrypted,
+//     record: RecordEncrypted,
+//     key: Key<Aes256Gcm>,
+// }
+//
+// impl VaultInterface {
+//     pub fn create(
+//         vault_file: VaultFile,
+//         schema_file: Rc<RefCell<SchemaFile>>,
+//         password: String,
+//     ) -> VaultInterface {
+//         let vault = VaultEncrypted::new(password.clone()).unwrap();
+//         let record = RecordEncrypted::new(password.clone()).unwrap();
+//         let key = vault.key(password);
+//         Self {
+//             vault_file,
+//             schema_file,
+//             vault,
+//             record,
+//             key,
+//         }
+//     }
+//
+//     pub fn open(
+//         vault_file: VaultFile,
+//         schema_file: Rc<RefCell<SchemaFile>>,
+//         password: String,
+//     ) -> Result<VaultInterface, Box<dyn Error>> {
+//         let vault: VaultEncrypted = vault_file.read()?.deserialize();
+//         let record = RecordEncrypted::new(password.clone()).unwrap();
+//         let key = vault.key(password);
+//         Ok(Self {
+//             vault_file,
+//             schema_file,
+//             vault,
+//             record,
+//             key,
+//         })
+//     }
+//
+//     // TODO: working around this function is clunky and error prone, refactor
+//     fn save(&mut self) -> Result<(), Box<dyn Error>> {
+//         self.vault_file.write(&self.vault)?;
+//         self.schema_file
+//             .borrow_mut()
+//             .write(&self.vault.decrypt(self.key)?.deserialize().schema())?;
+//         Ok(())
+//     }
+//
+//     fn transact(
+//         transaction: Commands,
+//         schema_file: Rc<RefCell<SchemaFile>>,
+//     ) -> Result<Output, Box<dyn Error>> {
+//         let mut interface = Self::get_interface(schema_file)?;
+//         let mut vault = interface.vault.decrypt(interface.key)?.deserialize();
+//         let (reads, record) = vault.transaction(transaction);
+//         interface.record.update(&record, interface.key)?;
+//
+//         let mut record_file = RecordFile::default();
+//         record_file.write(&interface.record)?;
+//         vault.apply_record(record);
+//         interface.vault.update(&vault, interface.key)?;
+//         interface.save()?;
+//         record_file.delete()?;
+//         Ok(reads.into())
+//     }
+//
+//     fn interact(
+//         interaction: Interaction,
+//         schema_file: Rc<RefCell<SchemaFile>>,
+//     ) -> Result<Output, Box<dyn Error>> {
+//         match interaction {
+//             Interaction::List => {
+//                 let schema = schema_file.borrow_mut().read()?.deserialize();
+//                 Ok(Output::List(schema.all_info()))
+//             }
+//             Interaction::Backup => {
+//                 let interface = Self::get_interface(schema_file)?;
+//                 let backup = interface.backup()?;
+//
+//                 Ok(Output::Backup(backup.path()))
+//             }
+//             Interaction::BackupList => {
+//                 let backups = BackupFile::all();
+//                 Ok(Output::List(
+//                     backups.into_iter().map(|b| b.to_string()).collect(),
+//                 ))
+//             }
+//             Interaction::BackupRestore => {
+//                 let backups = BackupFile::all();
+//                 let backup_file =
+//                     inquire::Select::new("Which backup to restore?", backups).prompt()?;
+//
+//                 let backup_password = inquire::Password::new("Backup's password:")
+//                     .with_display_toggle_enabled()
+//                     .with_display_mode(inquire::PasswordDisplayMode::Masked)
+//                     .without_confirmation()
+//                     .prompt()?;
+//                 let backup_vault_enc = backup_file.read()?.deserialize();
+//                 let backup_key = backup_vault_enc.key(backup_password);
+//                 let _backup_vault = backup_vault_enc.decrypt(backup_key)?.deserialize();
+//
+//                 let mut interface = Self::get_interface(schema_file)?;
+//                 let _vault = interface.vault.decrypt(interface.key)?.deserialize();
+//
+//                 // have proved that the user knows the backup's and current vault's password and
+//                 // the decryption of both, so make a backup of the current vault and then copy in
+//                 // the old vault as the current vault
+//                 let new_backup = interface.backup()?;
+//
+//                 interface.vault = backup_vault_enc;
+//                 interface.key = backup_key;
+//                 interface.save()?;
+//                 Ok(Output::Backup(new_backup.path()))
+//             }
+//             Interaction::Rotate => {
+//                 // TODO: does extra unnecessary decryption
+//                 let mut interface = Self::get_interface(schema_file)?;
+//                 let backup = interface.backup()?;
+//                 let vault = interface.vault.decrypt(interface.key)?.deserialize();
+//                 let new_password = inquire::Password::new("New vault password: ")
+//                     .with_display_toggle_enabled()
+//                     .with_display_mode(inquire::PasswordDisplayMode::Masked)
+//                     .prompt()?;
+//                 let mut new_vault = VaultEncrypted::new(new_password.clone())?;
+//                 new_vault.update(&vault, new_vault.key(new_password.clone()))?;
+//                 interface.vault = new_vault;
+//                 interface.key = interface.vault.key(new_password);
+//                 interface.save()?;
+//                 Ok(Output::Backup(backup.path()))
+//             }
+//         }
+//     }
+//
+//     fn backup(&self) -> Result<BackupFile, Box<dyn Error>> {
+//         let vault = self.vault.decrypt(self.key)?.deserialize();
+//         let mut backup_file = BackupFile::default();
+//         let backup = VaultEncrypted {
+//             salt: self.vault.salt.clone(),
+//             data: Encrypted::encrypt(&vault, self.key)?,
+//         };
+//         backup_file.write(&backup)?;
+//         Ok(backup_file)
+//     }
+//
+//     fn check_unfinished(&mut self) -> Result<(), Box<dyn Error>> {
+//         if let Some(file) = RecordFile::last() {
+//             let ans = Confirm::new("There appears to be an unapplied update, apply it? Will clear out old record if not applied.")
+//                 .with_default(true)
+//                 .with_help_message("Likely occurred due to some failure in saving off the updates from the previous interaction.")
+//                 .prompt();
+//
+//             match ans {
+//                 Ok(true) => self.apply_unfinished(file)?,
+//                 Ok(false) => file.delete()?,
+//                 Err(_) => (),
+//             }
+//         }
+//
+//         Ok(())
+//     }
+//
+//     fn apply_unfinished(&mut self, record_file: RecordFile) -> Result<(), Box<dyn Error>> {
+//         let mut vault = self.vault.decrypt(self.key)?.deserialize();
+//         let record = record_file
+//             .read()?
+//             .deserialize()
+//             .decrypt(self.key)?
+//             .deserialize();
+//         vault.apply_record(record);
+//         self.vault.update(&vault, self.key)?;
+//         self.save()?;
+//         record_file.delete()?;
+//         Ok(())
+//     }
+//
+//     fn get_interface(
+//         schema_file: Rc<RefCell<SchemaFile>>,
+//     ) -> Result<VaultInterface, Box<dyn Error>> {
+//         let vault_file = VaultFile::default();
+//         let mut interface = if vault_file.check() {
+//             let password = inquire::Password::new("Vault password: ")
+//                 .without_confirmation()
+//                 .with_display_toggle_enabled()
+//                 .with_display_mode(inquire::PasswordDisplayMode::Masked)
+//                 .prompt()?;
+//             let res = Self::open(vault_file, schema_file.clone(), password)?;
+//
+//             Ok::<VaultInterface, Box<dyn Error>>(res)
+//         } else {
+//             let new_password = inquire::Password::new("Vault doesn't exist, create password: ")
+//                 .with_display_toggle_enabled()
+//                 .with_display_mode(inquire::PasswordDisplayMode::Masked)
+//                 .prompt()?;
+//             let mut interface = Self::create(vault_file, schema_file.clone(), new_password);
+//             interface.save()?;
+//             Ok(interface)
+//         }?;
+//
+//         interface.check_unfinished()?;
+//         Ok(interface)
+//     }
+//
+//     pub fn interaction(transaction: CLICommands) -> Result<Output, Box<dyn Error>> {
+//         let schema_file: Rc<RefCell<SchemaFile>> = Rc::new(RefCell::new(SchemaFile::default()));
+//         let schema = if schema_file.borrow().check() {
+//             schema_file.borrow_mut().read()?.deserialize()
+//         } else {
+//             // ensure a file exists since it can get used later
+//             // TODO: should rework to make this not necessary
+//             let s = Schema::new(HashMap::new());
+//             schema_file.borrow_mut().write(&s)?;
+//             s
+//         };
+//
+//         let commands = Instructions::from_commands(transaction, schema)?;
+//         match commands {
+//             Instructions::Interaction(i) => Self::interact(i, schema_file),
+//             Instructions::Commands(c) => Self::transact(c, schema_file),
+//         }
+//     }
+// }

--- a/src/vault/encrypted.rs
+++ b/src/vault/encrypted.rs
@@ -35,6 +35,14 @@ impl VaultEncrypted {
         Encrypted::encrypt(&Vault::new(), key).map(|vault| Self { data: vault, salt })
     }
 
+    pub fn from_vault(
+        salt: String,
+        key: Key<Aes256Gcm>,
+        vault: &Vault,
+    ) -> Result<Self, Box<dyn Error>> {
+        Encrypted::encrypt(vault, key).map(|vault| Self { data: vault, salt })
+    }
+
     pub fn update(&mut self, data: &Vault, key: Key<Aes256Gcm>) -> Result<(), Box<dyn Error>> {
         let updated = Encrypted::encrypt(data, key)?;
         self.data = updated;

--- a/src/vault/interface.rs
+++ b/src/vault/interface.rs
@@ -1,240 +1,417 @@
 use std::{cell::RefCell, error::Error, rc::Rc};
 
 use aes_gcm::{Aes256Gcm, Key};
+use argon2::password_hash::SaltString;
+use rand::rngs::OsRng;
 
 use crate::{
-    cli::CLICommands,
-    command::{Commands, Instructions, Interaction},
+    command::{Command, Commands},
     file::{BackupFile, ProjectFile, RecordFile, SchemaFile, VaultFile},
+    message::Message,
     output::Output,
+    reads::Reads,
     schema::Schema,
     secure::{Encrypted, SecureData},
+    store::Store,
+    Password,
 };
 
-use super::encrypted::{RecordEncrypted, VaultEncrypted};
+use super::{
+    encrypted::{RecordEncrypted, VaultEncrypted},
+    Vault,
+};
 
 pub struct VaultInterface {
-    vault_file: VaultFile,
-    schema_file: Rc<RefCell<SchemaFile>>,
-    vault: VaultEncrypted,
-    record: RecordEncrypted,
+    vault: Vault,
+    vault_encrypted: VaultEncrypted,
     key: Key<Aes256Gcm>,
+    // schema: Schema,
+    record: RecordEncrypted,
+    schema_file: Rc<RefCell<SchemaFile>>,
+    vault_file: Rc<RefCell<VaultFile>>,
+    record_file: Rc<RefCell<RecordFile>>,
 }
 
 impl VaultInterface {
-    pub fn create(
-        vault_file: VaultFile,
-        schema_file: Rc<RefCell<SchemaFile>>,
-        password: String,
-    ) -> VaultInterface {
-        let vault = VaultEncrypted::new(password.clone()).unwrap();
-        let record = RecordEncrypted::new(password.clone()).unwrap();
-        let key = vault.key(password);
-        Self {
-            vault_file,
-            schema_file,
-            vault,
-            record,
-            key,
-        }
-    }
-
-    pub fn open(
-        vault_file: VaultFile,
-        schema_file: Rc<RefCell<SchemaFile>>,
-        password: String,
-    ) -> Result<VaultInterface, Box<dyn Error>> {
-        let vault: VaultEncrypted = vault_file.read()?.deserialize();
-        let record = RecordEncrypted::new(password.clone()).unwrap();
-        let key = vault.key(password);
-        Ok(Self {
-            vault_file,
-            schema_file,
-            vault,
-            record,
-            key,
-        })
-    }
-
-    // TODO: working around this function is clunky and error prone, refactor
-    fn save(&mut self) -> Result<(), Box<dyn Error>> {
-        self.vault_file.write(&self.vault)?;
-        self.schema_file
-            .borrow_mut()
-            .write(&self.vault.decrypt(self.key)?.deserialize().schema())?;
-        Ok(())
-    }
-
-    fn transact(
-        transaction: Commands,
-        schema_file: Rc<RefCell<SchemaFile>>,
-    ) -> Result<Output, Box<dyn Error>> {
-        let mut interface = Self::get_interface(schema_file)?;
-        let mut vault = interface.vault.decrypt(interface.key)?.deserialize();
-        let (reads, record) = vault.transaction(transaction);
-        interface.record.update(&record, interface.key)?;
-
-        let mut record_file = RecordFile::default();
-        record_file.write(&interface.record)?;
-        vault.apply_record(record);
-        interface.vault.update(&vault, interface.key)?;
-        interface.save()?;
-        record_file.delete()?;
-        Ok(reads.into())
-    }
-
-    fn interact(
-        interaction: Interaction,
-        schema_file: Rc<RefCell<SchemaFile>>,
-    ) -> Result<Output, Box<dyn Error>> {
-        match interaction {
-            Interaction::List => {
-                let schema = schema_file.borrow_mut().read()?.deserialize();
-                Ok(Output::List(schema.all_info()))
+    pub fn receive(message: Message) -> Result<Output, Box<dyn Error>> {
+        match message {
+            Message::Get(password, key) => {
+                let command = Command::Read { key };
+                let mut interface = Self::load_interface(password)?;
+                let reads = interface.transaction(command.into())?;
+                Ok(reads.into())
             }
-            Interaction::Backup => {
-                let interface = Self::get_interface(schema_file)?;
+            Message::Update(password, key, value) => {
+                let command = Command::Update { key, value };
+                let mut interface = Self::load_interface(password)?;
+                let reads = interface.transaction(command.into())?;
+                Ok(reads.into())
+            }
+            Message::Delete(password, key) => {
+                let command = Command::Delete { key };
+                let mut interface = Self::load_interface(password)?;
+                let _reads = interface.transaction(command.into())?;
+                Ok(().into())
+            }
+            Message::Backup(password) => {
+                let interface = Self::load_interface(password)?;
                 let backup = interface.backup()?;
-
-                Ok(Output::Backup(backup.path()))
+                Ok(Output::Backup(backup))
             }
-            Interaction::BackupList => {
-                let backups = BackupFile::all();
-                Ok(Output::List(
-                    backups.into_iter().map(|b| b.to_string()).collect(),
-                ))
+            Message::Rotate(password, new_password) => {
+                let mut interface = Self::load_interface(password)?;
+                let backup = interface.backup()?;
+                let new_vault = VaultEncrypted::new(new_password.clone())?;
+                let key = new_vault.key(new_password);
+                interface.vault_encrypted = new_vault;
+                interface.key = key;
+                interface.save()?;
+                Ok(Output::Backup(backup))
             }
-            Interaction::BackupRestore => {
-                let backups = BackupFile::all();
-                let backup_file =
-                    inquire::Select::new("Which backup to restore?", backups).prompt()?;
-
-                let backup_password = inquire::Password::new("Backup's password:")
-                    .with_display_toggle_enabled()
-                    .with_display_mode(inquire::PasswordDisplayMode::Masked)
-                    .without_confirmation()
-                    .prompt()?;
+            Message::Restore(password, backup_password, backup_file) => {
                 let backup_vault_enc = backup_file.read()?.deserialize();
                 let backup_key = backup_vault_enc.key(backup_password);
                 let _backup_vault = backup_vault_enc.decrypt(backup_key)?.deserialize();
 
-                let mut interface = Self::get_interface(schema_file)?;
-                let _vault = interface.vault.decrypt(interface.key)?.deserialize();
+                let mut interface = Self::load_interface(password)?;
 
                 // have proved that the user knows the backup's and current vault's password and
                 // the decryption of both, so make a backup of the current vault and then copy in
                 // the old vault as the current vault
                 let new_backup = interface.backup()?;
 
-                interface.vault = backup_vault_enc;
+                interface.vault_encrypted = backup_vault_enc;
                 interface.key = backup_key;
                 interface.save()?;
-                Ok(Output::Backup(new_backup.path()))
+                Ok(Output::Backup(new_backup))
             }
-            Interaction::Rotate => {
-                // TODO: does extra unnecessary decryption
-                let mut interface = Self::get_interface(schema_file)?;
-                let backup = interface.backup()?;
-                let vault = interface.vault.decrypt(interface.key)?.deserialize();
-                let new_password = inquire::Password::new("New vault password: ")
-                    .with_display_toggle_enabled()
-                    .with_display_mode(inquire::PasswordDisplayMode::Masked)
-                    .prompt()?;
-                let mut new_vault = VaultEncrypted::new(new_password.clone())?;
-                new_vault.update(&vault, new_vault.key(new_password.clone()))?;
-                interface.vault = new_vault;
-                interface.key = interface.vault.key(new_password);
-                interface.save()?;
-                Ok(Output::Backup(backup.path()))
+            Message::Schema => {
+                let schema = VaultInterface::get_schema();
+                Ok(Output::Schema(schema))
+            }
+            Message::BackupList => {
+                let files = BackupFile::all();
+                Ok(Output::BackupFiles(files))
             }
         }
     }
 
-    fn backup(&self) -> Result<BackupFile, Box<dyn Error>> {
-        let vault = self.vault.decrypt(self.key)?.deserialize();
-        let mut backup_file = BackupFile::default();
-        let backup = VaultEncrypted {
-            salt: self.vault.salt.clone(),
-            data: Encrypted::encrypt(&vault, self.key)?,
+    fn get_schema() -> Schema {
+        if let Ok(data) = SchemaFile::default().read() {
+            data.deserialize()
+        } else {
+            Schema::default()
+        }
+    }
+
+    fn load_interface(password: Password) -> Result<VaultInterface, Box<dyn Error>> {
+        let mut interface = Self::get_interface(password)?;
+        interface.check_unfinished()?;
+        Ok(interface)
+    }
+
+    fn get_interface(password: Password) -> Result<Self, Box<dyn Error>> {
+        let vault_file = VaultFile::default();
+        let record_file = RecordFile::default();
+        let schema_file = SchemaFile::default();
+        // let schema = Self::get_schema();
+        let record = RecordEncrypted::new(password.clone())?;
+        let (vault, key, vault_encrypted) = if vault_file.exists() {
+            let vault_encrypted = vault_file.read()?.deserialize();
+            let key = vault_encrypted.key(password);
+            let vault = vault_encrypted.decrypt(key)?.deserialize();
+            (vault, key, vault_encrypted)
+        } else {
+            let vault = Vault::new();
+            let salt = SaltString::generate(&mut OsRng);
+            let key = VaultEncrypted::get_key(salt.as_str(), password);
+            let vault_encrypted = VaultEncrypted::from_vault(salt.to_string(), key, &vault)?;
+            (vault, key, vault_encrypted)
         };
-        backup_file.write(&backup)?;
-        Ok(backup_file)
+
+        Ok(Self {
+            vault,
+            vault_encrypted,
+            key,
+            // schema,
+            record,
+            vault_file: Rc::new(RefCell::new(vault_file)),
+            record_file: Rc::new(RefCell::new(record_file)),
+            schema_file: Rc::new(RefCell::new(schema_file)),
+        })
     }
 
     fn check_unfinished(&mut self) -> Result<(), Box<dyn Error>> {
         if let Some(file) = RecordFile::last() {
-            let ans = inquire::Confirm::new("There appears to be an unapplied update, apply it? Will clear out old record if not applied.")
-                .with_default(true)
-                .with_help_message("Likely occurred due to some failure in saving off the updates from the previous interaction.")
-                .prompt();
-
-            match ans {
-                Ok(true) => self.apply_unfinished(file)?,
-                Ok(false) => file.delete()?,
-                Err(_) => (),
-            }
+            self.apply_unfinished(file)?
         }
 
         Ok(())
     }
 
     fn apply_unfinished(&mut self, record_file: RecordFile) -> Result<(), Box<dyn Error>> {
-        let mut vault = self.vault.decrypt(self.key)?.deserialize();
         let record = record_file
             .read()?
             .deserialize()
             .decrypt(self.key)?
             .deserialize();
-        vault.apply_record(record);
-        self.vault.update(&vault, self.key)?;
+        self.vault.apply_record(record);
         self.save()?;
         record_file.delete()?;
         Ok(())
     }
 
-    fn get_interface(
-        schema_file: Rc<RefCell<SchemaFile>>,
-    ) -> Result<VaultInterface, Box<dyn Error>> {
-        let vault_file = VaultFile::default();
-        let mut interface = if vault_file.check() {
-            let password = inquire::Password::new("Vault password: ")
-                .without_confirmation()
-                .with_display_toggle_enabled()
-                .with_display_mode(inquire::PasswordDisplayMode::Masked)
-                .prompt()?;
-            let res = Self::open(vault_file, schema_file.clone(), password)?;
-
-            Ok::<VaultInterface, Box<dyn Error>>(res)
-        } else {
-            let new_password = inquire::Password::new("Vault doesn't exist, create password: ")
-                .with_display_toggle_enabled()
-                .with_display_mode(inquire::PasswordDisplayMode::Masked)
-                .prompt()?;
-            let mut interface = Self::create(vault_file, schema_file.clone(), new_password);
-            interface.save()?;
-            Ok(interface)
-        }?;
-
-        interface.check_unfinished()?;
-        Ok(interface)
+    fn save(&mut self) -> Result<(), Box<dyn Error>> {
+        self.vault_encrypted.update(&self.vault, self.key)?;
+        self.vault_file.borrow_mut().write(&self.vault_encrypted)?;
+        self.schema_file.borrow_mut().write(&self.vault.schema())?;
+        Ok(())
     }
 
-    pub fn interaction(transaction: CLICommands) -> Result<Output, Box<dyn Error>> {
-        let schema_file: Rc<RefCell<SchemaFile>> = Rc::new(RefCell::new(SchemaFile::default()));
-        let schema = if schema_file.borrow().check() {
-            schema_file.borrow_mut().read()?.deserialize()
-        } else {
-            // ensure a file exists since it can get used later
-            // TODO: should rework to make this not necessary
-            let s = Schema::default();
-            schema_file.borrow_mut().write(&s)?;
-            s
+    fn backup(&self) -> Result<BackupFile, Box<dyn Error>> {
+        let mut backup_file = BackupFile::default();
+        let backup = VaultEncrypted {
+            salt: self.vault_encrypted.salt.clone(),
+            data: Encrypted::encrypt(&self.vault, self.key)?,
         };
+        backup_file.write(&backup)?;
+        Ok(backup_file)
+    }
 
-        let commands = Instructions::from_commands(transaction, schema)?;
-        match commands {
-            Instructions::Interaction(i) => Self::interact(i, schema_file),
-            Instructions::Commands(c) => Self::transact(c, schema_file),
-        }
+    fn transaction(&mut self, commands: Commands) -> Result<Reads<Store>, Box<dyn Error>> {
+        let (reads, record) = self.vault.transaction(commands);
+        self.record.update(&record, self.key)?;
+
+        self.record_file.borrow_mut().write(&self.record)?;
+        self.vault.apply_record(record);
+        self.save()?;
+        self.record_file.borrow_mut().delete()?;
+        Ok(reads)
     }
 }
+
+// pub struct VaultInterface {
+//     vault_file: VaultFile,
+//     schema_file: Rc<RefCell<SchemaFile>>,
+//     vault: VaultEncrypted,
+//     record: RecordEncrypted,
+//     key: Key<Aes256Gcm>,
+// }
+//
+// impl VaultInterface {
+//     pub fn create(
+//         vault_file: VaultFile,
+//         schema_file: Rc<RefCell<SchemaFile>>,
+//         password: String,
+//     ) -> VaultInterface {
+//         let vault = VaultEncrypted::new(password.clone()).unwrap();
+//         let record = RecordEncrypted::new(password.clone()).unwrap();
+//         let key = vault.key(password);
+//         Self {
+//             vault_file,
+//             schema_file,
+//             vault,
+//             record,
+//             key,
+//         }
+//     }
+//
+//     pub fn open(
+//         vault_file: VaultFile,
+//         schema_file: Rc<RefCell<SchemaFile>>,
+//         password: String,
+//     ) -> Result<VaultInterface, Box<dyn Error>> {
+//         let vault: VaultEncrypted = vault_file.read()?.deserialize();
+//         let record = RecordEncrypted::new(password.clone()).unwrap();
+//         let key = vault.key(password);
+//         Ok(Self {
+//             vault_file,
+//             schema_file,
+//             vault,
+//             record,
+//             key,
+//         })
+//     }
+//
+//     // TODO: working around this function is clunky and error prone, refactor
+//     fn save(&mut self) -> Result<(), Box<dyn Error>> {
+//         self.vault_file.write(&self.vault)?;
+//         self.schema_file
+//             .borrow_mut()
+//             .write(&self.vault.decrypt(self.key)?.deserialize().schema())?;
+//         Ok(())
+//     }
+//
+//     fn transact(
+//         transaction: Commands,
+//         schema_file: Rc<RefCell<SchemaFile>>,
+//     ) -> Result<Output, Box<dyn Error>> {
+//         let mut interface = Self::get_interface(schema_file)?;
+//         let mut vault = interface.vault.decrypt(interface.key)?.deserialize();
+//         let (reads, record) = vault.transaction(transaction);
+//         interface.record.update(&record, interface.key)?;
+//
+//         let mut record_file = RecordFile::default();
+//         record_file.write(&interface.record)?;
+//         vault.apply_record(record);
+//         interface.vault.update(&vault, interface.key)?;
+//         interface.save()?;
+//         record_file.delete()?;
+//         Ok(reads.into())
+//     }
+//
+//     fn interact(
+//         interaction: Interaction,
+//         schema_file: Rc<RefCell<SchemaFile>>,
+//     ) -> Result<Output, Box<dyn Error>> {
+//         match interaction {
+//             Interaction::List => {
+//                 let schema = schema_file.borrow_mut().read()?.deserialize();
+//                 Ok(Output::List(schema.all_info()))
+//             }
+//             Interaction::Backup => {
+//                 let interface = Self::get_interface(schema_file)?;
+//                 let backup = interface.backup()?;
+//
+//                 Ok(Output::Backup(backup.path()))
+//             }
+//             Interaction::BackupList => {
+//                 let backups = BackupFile::all();
+//                 Ok(Output::List(
+//                     backups.into_iter().map(|b| b.to_string()).collect(),
+//                 ))
+//             }
+//             Interaction::BackupRestore => {
+//                 let backups = BackupFile::all();
+//                 let backup_file =
+//                     inquire::Select::new("Which backup to restore?", backups).prompt()?;
+//
+//                 let backup_password = inquire::Password::new("Backup's password:")
+//                     .with_display_toggle_enabled()
+//                     .with_display_mode(inquire::PasswordDisplayMode::Masked)
+//                     .without_confirmation()
+//                     .prompt()?;
+//                 let backup_vault_enc = backup_file.read()?.deserialize();
+//                 let backup_key = backup_vault_enc.key(backup_password);
+//                 let _backup_vault = backup_vault_enc.decrypt(backup_key)?.deserialize();
+//
+//                 let mut interface = Self::get_interface(schema_file)?;
+//                 let _vault = interface.vault.decrypt(interface.key)?.deserialize();
+//
+//                 // have proved that the user knows the backup's and current vault's password and
+//                 // the decryption of both, so make a backup of the current vault and then copy in
+//                 // the old vault as the current vault
+//                 let new_backup = interface.backup()?;
+//
+//                 interface.vault = backup_vault_enc;
+//                 interface.key = backup_key;
+//                 interface.save()?;
+//                 Ok(Output::Backup(new_backup.path()))
+//             }
+//             Interaction::Rotate => {
+//                 // TODO: does extra unnecessary decryption
+//                 let mut interface = Self::get_interface(schema_file)?;
+//                 let backup = interface.backup()?;
+//                 let vault = interface.vault.decrypt(interface.key)?.deserialize();
+//                 let new_password = inquire::Password::new("New vault password: ")
+//                     .with_display_toggle_enabled()
+//                     .with_display_mode(inquire::PasswordDisplayMode::Masked)
+//                     .prompt()?;
+//                 let mut new_vault = VaultEncrypted::new(new_password.clone())?;
+//                 new_vault.update(&vault, new_vault.key(new_password.clone()))?;
+//                 interface.vault = new_vault;
+//                 interface.key = interface.vault.key(new_password);
+//                 interface.save()?;
+//                 Ok(Output::Backup(backup.path()))
+//             }
+//         }
+//     }
+//
+//     fn backup(&self) -> Result<BackupFile, Box<dyn Error>> {
+//         let vault = self.vault.decrypt(self.key)?.deserialize();
+//         let mut backup_file = BackupFile::default();
+//         let backup = VaultEncrypted {
+//             salt: self.vault.salt.clone(),
+//             data: Encrypted::encrypt(&vault, self.key)?,
+//         };
+//         backup_file.write(&backup)?;
+//         Ok(backup_file)
+//     }
+//
+//     fn check_unfinished(&mut self) -> Result<(), Box<dyn Error>> {
+//         if let Some(file) = RecordFile::last() {
+//             let ans = inquire::Confirm::new("There appears to be an unapplied update, apply it? Will clear out old record if not applied.")
+//                 .with_default(true)
+//                 .with_help_message("Likely occurred due to some failure in saving off the updates from the previous interaction.")
+//                 .prompt();
+//
+//             match ans {
+//                 Ok(true) => self.apply_unfinished(file)?,
+//                 Ok(false) => file.delete()?,
+//                 Err(_) => (),
+//             }
+//         }
+//
+//         Ok(())
+//     }
+//
+//     fn apply_unfinished(&mut self, record_file: RecordFile) -> Result<(), Box<dyn Error>> {
+//         let mut vault = self.vault.decrypt(self.key)?.deserialize();
+//         let record = record_file
+//             .read()?
+//             .deserialize()
+//             .decrypt(self.key)?
+//             .deserialize();
+//         vault.apply_record(record);
+//         self.vault.update(&vault, self.key)?;
+//         self.save()?;
+//         record_file.delete()?;
+//         Ok(())
+//     }
+//
+//     fn get_interface(
+//         schema_file: Rc<RefCell<SchemaFile>>,
+//     ) -> Result<VaultInterface, Box<dyn Error>> {
+//         let vault_file = VaultFile::default();
+//         let mut interface = if vault_file.check() {
+//             let password = inquire::Password::new("Vault password: ")
+//                 .without_confirmation()
+//                 .with_display_toggle_enabled()
+//                 .with_display_mode(inquire::PasswordDisplayMode::Masked)
+//                 .prompt()?;
+//             let res = Self::open(vault_file, schema_file.clone(), password)?;
+//
+//             Ok::<VaultInterface, Box<dyn Error>>(res)
+//         } else {
+//             let new_password = inquire::Password::new("Vault doesn't exist, create password: ")
+//                 .with_display_toggle_enabled()
+//                 .with_display_mode(inquire::PasswordDisplayMode::Masked)
+//                 .prompt()?;
+//             let mut interface = Self::create(vault_file, schema_file.clone(), new_password);
+//             interface.save()?;
+//             Ok(interface)
+//         }?;
+//
+//         interface.check_unfinished()?;
+//         Ok(interface)
+//     }
+//
+//     pub fn interaction(transaction: CLICommands) -> Result<Output, Box<dyn Error>> {
+//         let schema_file: Rc<RefCell<SchemaFile>> = Rc::new(RefCell::new(SchemaFile::default()));
+//         let schema = if schema_file.borrow().check() {
+//             schema_file.borrow_mut().read()?.deserialize()
+//         } else {
+//             // ensure a file exists since it can get used later
+//             // TODO: should rework to make this not necessary
+//             let s = Schema::default();
+//             schema_file.borrow_mut().write(&s)?;
+//             s
+//         };
+//
+//         let commands = Instructions::from_commands(transaction, schema)?;
+//         match commands {
+//             Instructions::Interaction(i) => Self::interact(i, schema_file),
+//             Instructions::Commands(c) => Self::transact(c, schema_file),
+//         }
+//     }
+// }

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -1,3 +1,6 @@
+pub mod encrypted;
+pub mod interface;
+
 use core::str;
 use std::collections::HashMap;
 

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -93,11 +93,11 @@ impl Vault {
         self.data.into_keys().collect()
     }
 
-    pub fn schema(self) -> Schema {
-        self.data
-            .into_iter()
-            .map(|(key, value)| (key, value.repr()))
-            .collect::<HashMap<String, String>>()
-            .into()
+    pub fn schema(&self) -> Schema {
+        let mut map: HashMap<String, String> = HashMap::new();
+        for (key, value) in &self.data {
+            map.insert(key.to_string(), value.repr());
+        }
+        map.into()
     }
 }


### PR DESCRIPTION
The interaction between a vault and the client is now done through `Message` and `VaultInterface::receive`.

So a client needs to generate `Message`s and then pass them to `VaultInterface::receive` and then handle the resulting `Output`.