### PR TITLE
Maintain field data when switching entry styles

### DIFF
--- a/src/gui/state/manager.rs
+++ b/src/gui/state/manager.rs
@@ -454,12 +454,11 @@ impl Application for ManagerState {
             GUIMessage::SelectStyle(choice) => {
                 if let Some(InternalState::New(new_state)) = self.active_state_mut() {
                     new_state.choice = choice;
-                    new_state.value = choice.convert_default().as_hash();
+                    // new_state.value = choice.convert_default().as_hash();
                 }
-                if let TempMessage::New(_, _, ref mut style, ref mut value) = &mut self.temp_message
-                {
+                if let TempMessage::New(_, _, ref mut style, _) = &mut self.temp_message {
                     *style = choice;
-                    *value = choice.convert_default().as_hash();
+                    // *value = choice.convert_default().as_hash();
                 }
             }
             GUIMessage::UpdateField(k, v) => {


### PR DESCRIPTION
Originally when switching between "Password" and "Username/Password" would always switch to the default entry. Now maintains the data when switching.